### PR TITLE
Add a working prototype of issue and pull request templates specific to IG work

### DIFF
--- a/.github/ISSUE_TEMPLATE/example.yaml
+++ b/.github/ISSUE_TEMPLATE/example.yaml
@@ -1,0 +1,64 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+projects: ["octo-org/1", "octo-org/44"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - 1.0.2 (Default)
+        - 1.0.3 (Edge)
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com). 
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/new_profile.md
+++ b/.github/ISSUE_TEMPLATE/new_profile.md
@@ -1,0 +1,10 @@
+Add new profile as shorthand file (in /input/fsh)
+Add example instance(s) and test profile - (Look at QA report /output/qa.html)
+Add to resource reference summary /pagecontent/resourcereferencesummary.md
+Check if it needs adding to /pagecontent/profiles-and-extensions.md
+Add to Variance statement /pagecontent/variance.md
+Update any mentions in the  AUeReqDI Mappings page  /pagecontent/auereqdi.md
+Add any valuesets/codesystems and profiles where used to /pagecontent/terminology.md
+add to conformance for the 4 actors  /resources/au-erequesting-filler.xml  , /resources/au-erequesting-placer.xml , /resources/au-erequesting-server.xml, /resources/au-erequesting-patient.xml
+add search param examples and conformance table (see task_notes.md and task_parameters.md for examples)
+finally add new profile to /pagecontent/changes.md

--- a/.github/ISSUE_TEMPLATE/new_profile.yaml
+++ b/.github/ISSUE_TEMPLATE/new_profile.yaml
@@ -1,0 +1,62 @@
+name: Add New Profile
+description: Template for creating a new profile.
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Add New Profile
+
+        Use this template to create a new profile and ensure all necessary steps are completed.
+
+  - type: input
+    id: profile_name
+    attributes:
+      label: Profile Name
+      description: Enter the name of the new profile.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: tasks
+    attributes:
+      label: Task Checklist
+      options:
+        - label: Add new profile as shorthand file (in /input/fsh)
+        - label: Add example instance(s) and test profile - (Look at QA report /output/qa.html)
+        - label: Add to resource reference summary /pagecontent/resourcereferencesummary.md
+        - label: Check if it needs adding to /pagecontent/profiles-and-extensions.md
+        - label: Add to Variance statement /pagecontent/variance.md
+        - label: Update any mentions in the AUeReqDI Mappings page /pagecontent/auereqdi.md
+        - label: Add any valuesets/codesystems and profiles where used to /pagecontent/terminology.md
+        - label: Add to conformance for the 4 actors /resources/au-erequesting-filler.xml, /resources/au-erequesting-placer.xml, /resources/au-erequesting-server.xml, /resources/au-erequesting-patient.xml
+        - label: Add search param examples and conformance table (see task_notes.md and task_parameters.md for examples)
+        - label: Add new profile to /pagecontent/changes.md
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: Add any additional notes or details about the new profile.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Creator Information
+
+  - type: input
+    id: creator_name
+    attributes:
+      label: Creator Name
+    validations:
+      required: true
+
+  - type: input
+    id: creation_date
+    attributes:
+      label: Creation Date
+      placeholder: YYYY-MM-DD
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/profile_review.yaml
+++ b/.github/ISSUE_TEMPLATE/profile_review.yaml
@@ -1,0 +1,89 @@
+name: Local Profile Review
+description: Template for reviewing local profiles.
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Local Profile Review
+
+        Use this template to review local profiles and ensure they meet the necessary standards and best practices.
+
+  - type: checkboxes
+    id: ig_location
+    attributes:
+      label: Living in the right IG (Base, Core, Use Case)?
+      options:
+        - label: Profile is in the correct IG.
+
+  - type: checkboxes
+    id: metadata_documentation
+    attributes:
+      label: Appropriate metadata and documentation in place?
+      options:
+        - label: Appropriate metadata and documentation are in place.
+
+  - type: checkboxes
+    id: overconstrained
+    attributes:
+      label: Not overconstrained?
+      options:
+        - label: Profile is not overconstrained.
+
+  - type: checkboxes
+    id: local_extensions
+    attributes:
+      label: "For any local extensions:"
+      options:
+        - label: Can the same goal be achieved without an extension (e.g., by linking to another resource)?
+        - label: No HL7 extension available?
+        - label: Value(x) element appropriately constrained?
+
+  - type: checkboxes
+    id: references
+    attributes:
+      label: References point to correct profile (e.g., point to PH Core rather than Int'l resource)?
+      options:
+        - label: References point to the correct profile.
+
+  - type: checkboxes
+    id: valueset_bindings
+    attributes:
+      label: ValueSet bindings correct (points to right VS, right strength)?
+      options:
+        - label: ValueSet bindings are correct.
+
+  - type: checkboxes
+    id: search_parameters
+    attributes:
+      label: Search parameters correct, including obligations?
+      options:
+        - label: Search parameters are correct, including obligations.
+
+  - type: textarea
+    id: additional_notes
+    attributes:
+      label: Additional Notes
+      description: Add any other relevant information or comments.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Reviewer Information
+
+  - type: input
+    id: reviewer_name
+    attributes:
+      label: Reviewer Name
+    validations:
+      required: true
+
+  - type: input
+    id: review_date
+    attributes:
+      label: Review Date
+      placeholder: YYYY-MM-DD
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/valueset.yaml
+++ b/.github/ISSUE_TEMPLATE/valueset.yaml
@@ -1,0 +1,123 @@
+name: Local ValueSet Review
+description: Template for reviewing local ValueSets.
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Local ValueSet Review
+
+        Use this template to review local ValueSets and ensure they meet the necessary standards and best practices.
+
+  - type: checkboxes
+    id: metadata
+    attributes:
+      label: Appropriate metadata? Including canonical URL, owner info, version info, etc.
+      options:
+        - label: Metadata is present and complete.
+
+  - type: checkboxes
+    id: hl7_vs
+    attributes:
+      label: No HL7 VS available?
+      options:
+        - label: No HL7 ValueSet is available.
+
+  - type: textarea
+    id: hl7_vs_note
+    attributes:
+      label: Note if there's a partial match it's better to constrain / extend the standard than to start completely from scratch.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: peer_countries
+    attributes:
+      label: Look at similar profiles from peer countries... is our VS in line with previous practices? If not... should it be?
+      options:
+        - label: Our ValueSet is in line with previous practices.
+        - label: Our ValueSet is not in line with previous practices.
+
+  - type: textarea
+    id: peer_countries_note
+    attributes:
+      label: If not, explain why it should be.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: definition
+    attributes:
+      label: Is the definition specified correctly (individual concepts vs whole trees)?
+      options:
+        - label: Definition is specified correctly.
+
+  - type: checkboxes
+    id: documentation
+    attributes:
+      label: Is documentation provided?
+      options:
+        - label: Documentation is provided.
+
+  - type: checkboxes
+    id: concept_standard
+    attributes:
+      label: For each concept in the VS, if it's from a standard, is it the right one (e.g., coming from the right tree in SNOMED)?
+      options:
+        - label: All concepts are from the correct standard.
+
+  - type: checkboxes
+    id: concept_local
+    attributes:
+      label: For each concept in the VS, if it's not from a standard, should it be requested, or is it really only useful in this context?
+      options:
+        - label: All local concepts are justified.
+
+  - type: checkboxes
+    id: designations
+    attributes:
+      label: For each concept in the VS, are the appropriate designations / synonyms available?
+      options:
+        - label: All concepts have appropriate designations / synonyms.
+
+  - type: checkboxes
+    id: hierarchy
+    attributes:
+      label: Does the VS have the appropriate hierarchy in place?
+      options:
+        - label: The ValueSet has the appropriate hierarchy.
+
+  - type: checkboxes
+    id: mappings
+    attributes:
+      label: If governance demands use of a local code but standards exist, are the appropriate mappings in place?
+      options:
+        - label: Appropriate mappings are in place.
+
+  - type: textarea
+    id: additional_notes
+    attributes:
+      label: Additional Notes
+      description: Add any other relevant information or comments.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Reviewer Information
+
+  - type: input
+    id: reviewer_name
+    attributes:
+      label: Reviewer Name
+    validations:
+      required: true
+
+  - type: input
+    id: review_date
+    attributes:
+      label: Review Date
+      placeholder: YYYY-MM-DD
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/valueset.yaml
+++ b/.github/ISSUE_TEMPLATE/valueset.yaml
@@ -1,4 +1,4 @@
-name: Local ValueSet Review
+name: ValueSet Review
 description: Template for reviewing local ValueSets.
 
 body:

--- a/.github/PULL_REQUEST_TEMPLATE/test.md
+++ b/.github/PULL_REQUEST_TEMPLATE/test.md
@@ -1,0 +1,3 @@
+- [x] #739
+- [ ] https://github.com/octo-org/octo-repo/issues/740
+- [ ] Add delight to the experience when all tasks are complete :tada:

--- a/.github/PULL_REQUEST_TEMPLATE/test.md
+++ b/.github/PULL_REQUEST_TEMPLATE/test.md
@@ -1,3 +1,12 @@
-- [x] #739
-- [ ] https://github.com/octo-org/octo-repo/issues/740
-- [ ] Add delight to the experience when all tasks are complete :tada:
+# Local Profile Review Template
+
+- [ ] Living in the right IG (Base, Core, Use Case)?
+- [ ] Appropriate metadata and documentation in place?
+- [ ] Not overconstrained?
+- [ ] For any local extensions:
+    - [ ] Can the same goal be achieved without an extension (e.g., by linking to another resource)?
+    - [ ] No HL7 extension available?
+    - [ ] Value(x) element appropriately constrained?
+- [ ] References point to correct profile (e.g., point to PH Core rather than Int'l resource)?
+- [ ] ValueSet bindings correct (points to right VS, right strength)?
+- [ ] Search parameters correct, including obligations?


### PR DESCRIPTION
closes #49 

This PR brings in a number of issue and PR templates, both as an example and initial work.

> With issue and pull request templates, you can customize and standardize the information you'd like contributors to include when they open issues and pull requests in your repository.

Their technical use is [described here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates). To actually put them into practice the [how and when](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) would need to be defined. This PR only contributes an implementation.

This PR also adds a [PR template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository). To use it, you need to use a certain [query parameter](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) `template`.

For example, the following URL, when entered in the browser once logged in

```
https://github.com/octo-org/octo-repo/compare/main...my-branch?quick_pull=1&template=issue_template.md
```

creates a pull request with a template in the pull request body. The template query parameter works with templates stored in a `PULL_REQUEST_TEMPLATE` subdirectory within the root, docs/ or .github/ directory in a repository.

It refers to repo `octo-org/octo-repo` and compares branches `main` and `my-branch`.